### PR TITLE
fix: malformed dockerconfigjson + fix ingress URLs produced from NOTES.txt 

### DIFF
--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Repo structure change
 
 ## 0.6.0
+
 * Allow for more advanced Sombra configurations to be deployed.
 * Allow for external metrics to be used with the Sombra HPA.
 * Allow for Datadog `DD_SERVICE_NAME` environment variable to be customizable.
@@ -34,7 +35,13 @@
 * Fix typos.
 
 ## 0.6.1
+
 * Fix the issue with the `isMultiTenant` parameter by converting it to a string before using it.
 
 ## 0.6.2
+
 * Fix issue with external metrics resolution for Sombras Horizontal Pod Autoscaler.
+
+## 0.6.3
+
+* Fixed a bug with the `secrets.yaml` template, which was causing this error during `helm install`: "Secret in version "v1" cannot be handled as a Secret: json: cannot unmarshal string into Go struct field Secret.data of type map[string][]uint8"

--- a/charts/sombra/Chart.yaml
+++ b/charts/sombra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sombra
 description: A Helm chart for deploying sombra and its dependent services in Kubernetes
 type: application
-version: 0.6.2
+version: 0.6.3
 maintainers:
 - name: Transcend
   email: dev@transcend.io

--- a/charts/sombra/templates/NOTES.txt
+++ b/charts/sombra/templates/NOTES.txt
@@ -1,43 +1,50 @@
-1. Get the Sombra transcend ingress URL by running these commands:
-{{- if .Values.transcend_ingress.enabled }}
-  {{- range $host := .Values.transcend_ingress.hosts }}
-    {{- range .paths }}
-    http{{ if $.Values.transcend_ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-    {{- end }}
-  {{- end }}
-{{- else if contains "NodePort" .Values.transcend_service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Values.namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "sombra-chart.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Values.namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.transcend_service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Values.namespace }} svc -w {{ include "sombra-chart.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Values.namespace }} {{ include "sombra-chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.transcend_service.port }}
-{{- else if contains "ClusterIP" .Values.transcend_service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Values.namespace }} -l "app.kubernetes.io/name={{ include "sombra-chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Values.namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  kubectl --namespace {{ .Values.namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
+Your release of Sombra is named {{ .Release.Name }}.
 
-2. Get the Sombra customer ingress URL by running these commands:
-{{- if .Values.customer_ingress.enabled }}
+1. Get Sombra's "Customer Ingress" URL by running these commands:
+{{ if .Values.customer_ingress.enabled }}
   {{- range $host := .Values.customer_ingress.hosts }}
     {{- range .paths }}
     http{{ if $.Values.customer_ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
     {{- end }}
   {{- end }}
 {{- else if contains "NodePort" .Values.customer_service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Values.namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "sombra-chart.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Values.namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "sombra-chart.fullname" . }}-customer-service)
   export NODE_IP=$(kubectl get nodes --namespace {{ .Values.namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.customer_service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Values.namespace }} svc -w {{ include "sombra-chart.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Values.namespace }} {{ include "sombra-chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  You can watch the status of by running 'kubectl get --namespace {{ .Values.namespace }} svc -w {{ include "sombra-chart.fullname" . }}-customer-service'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Values.namespace }} {{ include "sombra-chart.fullname" . }}-customer-service --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.customer_service.port }}
 {{- else if contains "ClusterIP" .Values.customer_service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Values.namespace }} -l "app.kubernetes.io/name={{ include "sombra-chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Values.namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  kubectl --namespace {{ .Values.namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Values.namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[?(@.name=='internal')].containerPort}")
+  kubectl --namespace {{ .Values.namespace }} port-forward $POD_NAME $CONTAINER_PORT:$CONTAINER_PORT
 {{- end }}
+
+
+2. If you are using the Direct Connection method (i.e., not Reverse Tunnel), get Sombra's "Transcend Ingress" URL by running these commands:
+{{ if .Values.transcend_ingress.enabled }}
+  {{- range $host := .Values.transcend_ingress.hosts }}
+    {{- range .paths }}
+    http{{ if $.Values.transcend_ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+    {{- end }}
+  {{- end }}
+{{- else if contains "NodePort" .Values.transcend_service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Values.namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "sombra-chart.fullname" . }}-transcend-service)
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Values.namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.transcend_service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  You can watch the status of by running 'kubectl get --namespace {{ .Values.namespace }} svc -w {{ include "sombra-chart.fullname" . }}-transcend-service'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Values.namespace }} {{ include "sombra-chart.fullname" . }}-transcend-service --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.transcend_service.port }}
+{{- else if contains "ClusterIP" .Values.transcend_service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Values.namespace }} -l "app.kubernetes.io/name={{ include "sombra-chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Values.namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[?(@.name=='external')].containerPort}")
+  kubectl --namespace {{ .Values.namespace }} port-forward $POD_NAME $CONTAINER_PORT:$CONTAINER_PORT
+{{- end }}
+
+For more information, visit https://docs.transcend.io/docs/articles/sombra/deploying/deployment-options/helm.

--- a/charts/sombra/templates/secrets.yaml
+++ b/charts/sombra/templates/secrets.yaml
@@ -7,8 +7,8 @@ metadata:
   name: sombra-secrets
 type: Opaque
 data:
-  {{- range .Values.envs_as_secret }}
-  {{ .name }}: {{ .value | b64enc | quote }}
+  {{- range $name, $value := .Values.envs_as_secret }}
+  {{ $value.name }}: {{ $value.value | b64enc | quote }}
   {{- end }}
 ---
 {{- end }}

--- a/charts/sombra/templates/secrets.yaml
+++ b/charts/sombra/templates/secrets.yaml
@@ -7,8 +7,8 @@ metadata:
   name: sombra-secrets
 type: Opaque
 data:
-  {{- range $name, $value := .Values.envs_as_secret }}
-  {{ $value.name }}: {{ $value.value | b64enc | quote  }}
+  {{- range .Values.envs_as_secret }}
+  {{ .name }}: {{ .value | b64enc | quote }}
   {{- end }}
 ---
 {{- end }}
@@ -21,5 +21,5 @@ metadata:
   name: transcend-registry
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}" .Values.imageCredentials.registry .Values.imageCredentials.username .Values.imageCredentials.password (printf "%s:%s" .Values.imageCredentials.username .Values.imageCredentials.password | b64enc) | b64enc }}
+  .dockerconfigjson: {{ printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}" .Values.imageCredentials.registry .Values.imageCredentials.username .Values.imageCredentials.password (printf "%s:%s" .Values.imageCredentials.username .Values.imageCredentials.password | b64enc) | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
## Issue

- closes T-46117

The Helm chart was failing to install with the error:

```console
Error: INSTALLATION FAILED: 1 error occurred:
Secret in version "v1" cannot be handled as a Secret: json: cannot unmarshal string into Go struct field Secret.data of type map[string][]uint8
```

## Root Cause
A template syntax issue caused the Secret to be malformed:

The dockerconfigjson field was not properly formatted in the YAML output, causing parsing issues:
```yaml
# Original (incorrect)
.dockerconfigjson: {{- printf "..." | b64enc }}

# Fixed
.dockerconfigjson: {{ printf "..." | b64enc | quote }}
```

The rendered output changes like so:

<img width="914" alt="Screenshot 2025-06-11 at 6 07 07 PM" src="https://github.com/user-attachments/assets/b57f4728-a244-4b3f-a72d-17a9e120644e" />


## Changes
- Improved dockerconfigjson formatting by:
  - Removing the `-` from `{{-` to preserve proper YAML spacing
  - Adding `quote` function to ensure proper string escaping
  - Ensuring proper spacing after the `:` in the YAML output

## Testing
The changes have been tested with a values.yaml containing:
- Image credentials for registry authentication

The Secret now renders correctly and can be properly parsed by Kubernetes.

## Impact
This fix ensures that:
1. Docker registry credentials are correctly formatted in the dockerconfigjson Secret
2. The Helm chart can be installed without YAML parsing errors

## Misc Changes
Fixed NOTES.txt to pick the correct URLs for Customer Ingress and Transcend Ingress. Before, it was picking the same port for each.