### PR TITLE
ROBOT: Add optional service account name support

### DIFF
--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -49,7 +49,7 @@
 ## 0.6.4
 
 * Added support for specifying an optional service account name in the chart's values
-* Added serviceAccount configuration section with create, automount, annotations, and name options
+* Added optional serviceAccount configuration section (commented out by default)
 * Created serviceaccount.yaml template for conditional service account creation
-* Updated deployment to use the specified service account
-* **BREAKING CHANGE**: Default `serviceAccount.create` to `false` - users must specify existing service account names
+* Updated deployment to conditionally use the specified service account
+* **Non-breaking change**: Service account functionality is completely opt-in and disabled by default

--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -52,3 +52,4 @@
 * Added serviceAccount configuration section with create, automount, annotations, and name options
 * Created serviceaccount.yaml template for conditional service account creation
 * Updated deployment to use the specified service account
+* **BREAKING CHANGE**: Default `serviceAccount.create` to `false` - users must specify existing service account names

--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -45,3 +45,10 @@
 ## 0.6.3
 
 * Fixed a bug with the `secrets.yaml` template, which was causing this error during `helm install`: "Secret in version "v1" cannot be handled as a Secret: json: cannot unmarshal string into Go struct field Secret.data of type map[string][]uint8"
+
+## 0.6.4
+
+* Added support for specifying an optional service account name in the chart's values
+* Added serviceAccount configuration section with create, automount, annotations, and name options
+* Created serviceaccount.yaml template for conditional service account creation
+* Updated deployment to use the specified service account

--- a/charts/sombra/Chart.yaml
+++ b/charts/sombra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sombra
 description: A Helm chart for deploying sombra and its dependent services in Kubernetes
 type: application
-version: 0.6.3
+version: 0.6.4
 maintainers:
 - name: Transcend
   email: dev@transcend.io

--- a/charts/sombra/templates/_helpers.tpl
+++ b/charts/sombra/templates/_helpers.tpl
@@ -54,9 +54,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "sombra-chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount }}
 {{- if .Values.serviceAccount.create }}
 {{- default (include "sombra-chart.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- else }}
+{{- "default" }}
 {{- end }}
 {{- end }}

--- a/charts/sombra/templates/deployment.yaml
+++ b/charts/sombra/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "sombra-chart.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/sombra/templates/deployment.yaml
+++ b/charts/sombra/templates/deployment.yaml
@@ -29,7 +29,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccount }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "sombra-chart.serviceAccountName" . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/sombra/templates/serviceaccount.yaml
+++ b/charts/sombra/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.serviceAccount .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sombra/templates/serviceaccount.yaml
+++ b/charts/sombra/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sombra-chart.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "sombra-chart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -41,7 +41,7 @@ fullnameOverride: ""
 # Service account configuration
 serviceAccount:
   # Specifies whether a service account should be created
-  create: true
+  create: false
   # Automatically mount a ServiceAccount's API credentials?
   automount: true
   # Annotations to add to the service account

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -38,17 +38,19 @@ nameOverride: ""
 # Override the full qualified app name
 fullnameOverride: ""
 
-# Service account configuration
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: false
-  # Automatically mount a ServiceAccount's API credentials?
-  automount: true
-  # Annotations to add to the service account
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: ""
+# Service account configuration (optional)
+# Uncomment and configure this section if you want to use a custom service account
+# If not specified, no serviceAccountName will be set in the deployment (default K8s behavior)
+# serviceAccount:
+#   # Specifies whether a service account should be created
+#   create: false
+#   # Automatically mount a ServiceAccount's API credentials?
+#   automount: true
+#   # Annotations to add to the service account
+#   annotations: {}
+#   # The name of the service account to use.
+#   # If not set and create is true, a name is generated using the fullname template
+#   name: ""
 
 # Define annotations for the Sombra pod
 podAnnotations: {}

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -38,6 +38,18 @@ nameOverride: ""
 # Override the full qualified app name
 fullnameOverride: ""
 
+# Service account configuration
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 # Define annotations for the Sombra pod
 podAnnotations: {}
 # Define labels for the Sombra pod


### PR DESCRIPTION
Written by cursor: https://transcend-inc.slack.com/archives/C058SBMUXLY/p1750902085238539?thread_ts=1750901883.476299&cid=C058SBMUXLY

The idea here is to allow specifying a service name so that it can be attached to AWS IAM Roles (or other cloud IAM concepts)