### PR TITLE
support client-managed secrets

### DIFF
--- a/charts/sombra/templates/deployment.yaml
+++ b/charts/sombra/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.envFrom }}
+          envFrom:
+{{- toYaml .Values.envFrom | nindent 12 }}
+          {{- end }}
           env:
             {{- if gt $envs_as_secret_len 0  -}}
             {{- range $name, $value := .Values.envs_as_secret }}

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -141,6 +141,8 @@ transcend_ingress:
 # Configure the container service with the minimum set of environment variables
 # @see https://docs.transcend.io/docs/security/end-to-end-encryption/deploying-sombra#3.-configure-the-container-service-with-the-minimum-set-of-environment-variables
 
+envFrom: []
+
 # These environment variables are saved as secret
 envs_as_secret:
   - name: JWT_ECDSA_KEY


### PR DESCRIPTION
current chart implementation requires the client to pass in secret values in the `helm install` step, either in the `values.yaml` file or as `--set` parameters. For environments managed entirely via IaC (eg ArgoCD), this is security risk as it forces committing secrets to git repo for deployment.

This change adds an optional `envFrom` parameter, which if provided, will reference an (expected to be) client-created secret, enabling the use of External Secrets Operator and/or other decoupled secrets managers.