### PR TITLE
Support for optional pod-level and container-level securityContext configuration

### DIFF
--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -49,13 +49,20 @@
 ## 0.6.4
 
 * Added support for specifying an optional service account name in the chart's values
-* Added optional serviceAccount configuration section (commented out by default)
-* Created serviceaccount.yaml template for conditional service account creation
-* Updated deployment to conditionally use the specified service account
-* **Non-breaking change**: Service account functionality is completely opt-in and disabled by default
+  * Added optional serviceAccount configuration section (commented out by default)
+  * Created serviceaccount.yaml template for conditional service account creation
+  * Updated deployment to conditionally use the specified service account
+  * **Non-breaking change**: Service account functionality is completely opt-in and disabled by default
 
 ## 0.6.5
 
 * Added support for client-managed secrets via `envFrom` configuration
-* Allow loading environment variables from ConfigMaps and Secrets using the `envFrom` field
-* **Non-breaking change**: `envFrom` functionality is completely opt-in and disabled by default
+  * Allow loading environment variables from ConfigMaps and Secrets using the `envFrom` field
+  * **Non-breaking change**: `envFrom` functionality is completely opt-in and disabled by default
+
+## 0.6.6
+
+* Added support for pod-level and container-level securityContext configuration
+  * Allow users to configure security contexts for enhanced security and compliance
+  * Added `podSecurityContext` and `securityContext` options in values.yaml for all charts (sombra, llm-classifier, pathfinder)
+  * **Non-breaking change**: Security context functionality is completely opt-in and disabled by default

--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -62,7 +62,7 @@
 
 ## 0.6.6
 
-* Added support for pod-level and container-level securityContext configuration
+* Added support for pod-level and container-level [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) configuration
   * Allow users to configure security contexts for enhanced security and compliance
-  * Added `podSecurityContext` and `securityContext` options in values.yaml for all charts (sombra, llm-classifier, pathfinder)
+  * Added `podSecurityContext` and `containerSecurityContext` options in values.yaml for all charts (sombra, llm-classifier, pathfinder)
   * **Non-breaking change**: Security context functionality is completely opt-in and disabled by default

--- a/charts/sombra/Chart.yaml
+++ b/charts/sombra/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: sombra
 description: A Helm chart to deploy Sombra and its dependent services in a Kubernetes cluster
 type: application
-version: 0.6.5
+version: 0.6.6
 maintainers:
 - name: Transcend
   email: dev@transcend.io
 dependencies:
 - name: llm-classifier
   condition: llm-classifier.enabled
-  version: "0.2.1"
+  version: "0.2.2"
 - name: pathfinder
   condition: pathfinder.enabled
-  version: "0.2.1"
+  version: "0.2.2"

--- a/charts/sombra/charts/llm-classifier/Chart.yaml
+++ b/charts/sombra/charts/llm-classifier/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: llm-classifier
 description: A Helm chart to deploy the LLM Classifier in a Kubernetes cluster
 type: application
-version: 0.2.1
+version: 0.2.2

--- a/charts/sombra/charts/llm-classifier/templates/deployment.yaml
+++ b/charts/sombra/charts/llm-classifier/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.securityContext }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/sombra/charts/llm-classifier/templates/deployment.yaml
+++ b/charts/sombra/charts/llm-classifier/templates/deployment.yaml
@@ -29,10 +29,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.envFrom }}
           envFrom:
             {{- toYaml .Values.envFrom | nindent 12 }}

--- a/charts/sombra/charts/llm-classifier/values.yaml
+++ b/charts/sombra/charts/llm-classifier/values.yaml
@@ -27,6 +27,30 @@ podAnnotations: {}
 # Define lables for sombra pod
 podLabels: {}
 
+# Security context configuration
+# Pod-level security context
+podSecurityContext: {}
+  # fsGroup: 1000
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # runAsGroup: 1000
+  # supplementalGroups: []
+  # seccompProfile:
+  #   type: RuntimeDefault
+
+# Container-level security context
+securityContext: {}
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # runAsGroup: 1000
+  # allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop:
+  #     - ALL
+  # readOnlyRootFilesystem: true
+  # seccompProfile:
+  #   type: RuntimeDefault
+
 # Define llm-classifier networking
 service:
   type: ClusterIP

--- a/charts/sombra/charts/llm-classifier/values.yaml
+++ b/charts/sombra/charts/llm-classifier/values.yaml
@@ -39,7 +39,7 @@ podSecurityContext: {}
   #   type: RuntimeDefault
 
 # Container-level security context
-securityContext: {}
+containerSecurityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
   # runAsGroup: 1000

--- a/charts/sombra/charts/pathfinder/Chart.yaml
+++ b/charts/sombra/charts/pathfinder/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: pathfinder
 description: A Helm chart to deploy Pathfinder in a Kubernetes cluster
 type: application
-version: 0.2.1
+version: 0.2.2

--- a/charts/sombra/charts/pathfinder/templates/deployment.yaml
+++ b/charts/sombra/charts/pathfinder/templates/deployment.yaml
@@ -29,9 +29,17 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.envFrom }}
           envFrom:
             {{- toYaml .Values.envFrom | nindent 12 }}

--- a/charts/sombra/charts/pathfinder/templates/deployment.yaml
+++ b/charts/sombra/charts/pathfinder/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          {{- with .Values.securityContext }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/sombra/charts/pathfinder/values.yaml
+++ b/charts/sombra/charts/pathfinder/values.yaml
@@ -27,6 +27,30 @@ podAnnotations: {}
 # Define lables for sombra pod
 podLabels: {}
 
+# Security context configuration
+# Pod-level security context
+podSecurityContext: {}
+  # fsGroup: 1000
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # runAsGroup: 1000
+  # supplementalGroups: []
+  # seccompProfile:
+  #   type: RuntimeDefault
+
+# Container-level security context
+securityContext: {}
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # runAsGroup: 1000
+  # allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop:
+  #     - ALL
+  # readOnlyRootFilesystem: true
+  # seccompProfile:
+  #   type: RuntimeDefault
+
 # Define Pathfinder networking
 service:
   type: ClusterIP

--- a/charts/sombra/charts/pathfinder/values.yaml
+++ b/charts/sombra/charts/pathfinder/values.yaml
@@ -39,7 +39,7 @@ podSecurityContext: {}
   #   type: RuntimeDefault
 
 # Container-level security context
-securityContext: {}
+containerSecurityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
   # runAsGroup: 1000

--- a/charts/sombra/templates/deployment.yaml
+++ b/charts/sombra/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.securityContext }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/sombra/templates/deployment.yaml
+++ b/charts/sombra/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.serviceAccount }}
       {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "sombra-chart.serviceAccountName" . }}
@@ -38,6 +42,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.envFrom }}
           envFrom:
             {{- toYaml .Values.envFrom | nindent 12 }}

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -69,7 +69,7 @@ podSecurityContext: {}
   #   type: RuntimeDefault
 
 # Container-level security context
-securityContext: {}
+containerSecurityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
   # runAsGroup: 1000

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -57,6 +57,30 @@ podAnnotations: {}
 # Define labels for the Sombra pod
 podLabels: {}
 
+# Security context configuration
+# Pod-level security context
+podSecurityContext: {}
+  # fsGroup: 1000
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # runAsGroup: 1000
+  # supplementalGroups: []
+  # seccompProfile:
+  #   type: RuntimeDefault
+
+# Container-level security context
+securityContext: {}
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # runAsGroup: 1000
+  # allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop:
+  #     - ALL
+  # readOnlyRootFilesystem: true
+  # seccompProfile:
+  #   type: RuntimeDefault
+
 ########### Sombra Architecture ###############
 # @see https://docs.transcend.io/docs/security/end-to-end-encryption/deploying-sombra
 #


### PR DESCRIPTION
Closes [BOW-4835: Update helm-charts to allow `securityContext` configuration](https://linear.app/transcend/issue/BOW-4835/update-helm-charts-to-allow-securitycontext-configuration)