### PR TITLE
Add support for host-aliases, and volume mounts to the Sombra containers.

### DIFF
--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -70,3 +70,7 @@
 ## 0.6.7
 
 * See 0.6.6. This is a re-release of 0.6.6 to test an updated chart release process.
+
+## 0.6.8
+
+* Added support for host-aliases, and volume mounts to the Sombra customer-ingress pods.

--- a/charts/sombra/Chart.yaml
+++ b/charts/sombra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sombra
 description: A Helm chart to deploy Sombra and its dependent services in a Kubernetes cluster
 type: application
-version: 0.6.7
+version: 0.6.8
 maintainers:
 - name: Transcend
   email: dev@transcend.io

--- a/charts/sombra/templates/deployment.yaml
+++ b/charts/sombra/templates/deployment.yaml
@@ -38,6 +38,14 @@ spec:
       serviceAccountName: {{ include "sombra-chart.serviceAccountName" . }}
       {{- end }}
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -81,6 +89,8 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -179,6 +179,14 @@ readinessProbe:
     port: 5042
     scheme: HTTP
 
+# Host-aliases to define on the pods.
+hostAliases: []
+
+# Volumes to add to the pods.
+volumes: []
+# Volume mounts to add to the pods.
+volumeMounts: []
+
 # Enable to use horizontal pod autoscaling based off metrics
 autoscaling:
   enabled: false


### PR DESCRIPTION
A test apply with e-shop-it successfully adds the config map as a volume mount, and appends the host aliases!

#### Plan
<img width="2126" height="979" alt="image" src="https://github.com/user-attachments/assets/7c62b83f-0a4d-41ef-b2fa-ad151bd2cfa7" />

#### Application of plan
<img width="1862" height="587" alt="image" src="https://github.com/user-attachments/assets/44f80bbf-d962-4c9c-bb87-e06a1b287100" />


### Linked Issues
- ref: https://linear.app/transcend/issue/KIR-8168/support-self-signed-ssl-certificates-with-odbcmongodb
- ref: https://linear.app/transcend/issue/BOW-4834/configure-etchosts-on-sombra-to-allow-piko-agent-to-connect-to 