### PR TITLE
Add startupProbe support to the Sombra chart

### DIFF
--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -92,3 +92,10 @@
 
 * Added support for Kubernetes Downward API `fieldRef` environment variables via `envs_field_ref`.
   * Supported in both the main Sombra chart and the sombra-job-scheduler subchart.
+
+## 0.11.0
+
+* Added support for a Kubernetes `startupProbe` on the Sombra container.
+  * Defaults to the same `/health` endpoint on port `5042` used by the existing liveness and readiness probes, with a longer `failureThreshold` to accommodate slow start-ups.
+  * Configurable via the `startupProbe` field in `values.yaml`. Set `startupProbe: null` to disable it entirely.
+  * **Non-breaking change**: existing deployments will pick up the default startup probe; behaviour can be reverted by overriding or disabling the value.

--- a/charts/sombra/Chart.yaml
+++ b/charts/sombra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sombra
 description: A Helm chart to deploy Sombra and its dependent services in a Kubernetes cluster
 type: application
-version: 0.10.0
+version: 0.11.0
 maintainers:
   - name: Transcend
     email: dev@transcend.io

--- a/charts/sombra/templates/deployment.yaml
+++ b/charts/sombra/templates/deployment.yaml
@@ -99,6 +99,10 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/sombra/tests/deployment_test.yaml
+++ b/charts/sombra/tests/deployment_test.yaml
@@ -78,6 +78,18 @@ tests:
             failureThreshold: 3
             successThreshold: 1
             periodSeconds: 10
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /health
+              port: 5042
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 30
+            failureThreshold: 30
+            successThreshold: 1
+            periodSeconds: 10
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -163,6 +175,45 @@ tests:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+
+  - it: should allow overriding startupProbe values
+    set:
+      namespace: test-ns
+      startupProbe:
+        httpGet:
+          path: /custom-health
+          port: 6042
+          scheme: HTTPS
+        initialDelaySeconds: 5
+        timeoutSeconds: 15
+        failureThreshold: 60
+        successThreshold: 1
+        periodSeconds: 5
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /custom-health
+              port: 6042
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            timeoutSeconds: 15
+            failureThreshold: 60
+            successThreshold: 1
+            periodSeconds: 5
+
+  - it: should not render startupProbe when disabled
+    set:
+      namespace: test-ns
+      startupProbe: null
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
 
   - it: should render both regular envs and fieldRef envs together
     set:

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -199,6 +199,19 @@ readinessProbe:
   failureThreshold: 3
   successThreshold: 1
   periodSeconds: 10
+# Startup probe gives the container additional time to come up before the
+# liveness and readiness probes begin running. Set `startupProbe: null` to
+# disable it entirely.
+startupProbe:
+  httpGet:
+    path: /health
+    port: 5042
+    scheme: HTTP
+  initialDelaySeconds: 10
+  timeoutSeconds: 30
+  failureThreshold: 30
+  successThreshold: 1
+  periodSeconds: 10
 
 # The default is 30 seconds.
 # We choose a higher grace period to allow more requests to complete.


### PR DESCRIPTION
Adds a configurable `startupProbe` to the Sombra container

## Issues
- closes https://linear.app/transcend/issue/BOW-5033/add-startupprobe-support-to-the-sombra-helm-chart

<details>
<summary>Details</summary>

- Defaults to the same `/health` endpoint on port `5042` used by the existing liveness and readiness probes.
- Uses a more permissive `failureThreshold` (30) and `timeoutSeconds` (30) so slow start-ups do not get killed before the probe succeeds; tune or disable (`startupProbe: null`) via `values.yaml`.
- Adds unit tests for the default render, an override, and the disable path; bumps the chart to `0.11.0` and updates the changelog.

### Test plan

- [x] \`helm unittest charts/sombra\` (9 tests, all passing)
- [x] \`helm lint charts/sombra\`
- [x] \`helm template charts/sombra\` shows the expected \`startupProbe\` block
- [x] \`helm template charts/sombra --set startupProbe=null\` omits \`startupProbe\`

</details>