### PR TITLE
Add opt-in OPA sidecar support to the Sombra chart

### DIFF
--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -106,5 +106,5 @@
   * Gated by `opa.enabled` (default `false`); existing single-container deployments are unchanged.
   * Configurable `opa.image`, `opa.args`, `opa.env`/`opa.envFrom`, `opa.resources`, `opa.securityContext`, `opa.livenessProbe`/`opa.readinessProbe`/`opa.startupProbe`, `opa.lifecycle`, `opa.port`, and supplemental `opa.volumeMounts`.
   * When `opa.config` is non-empty, a `<fullname>-opa-config` ConfigMap is rendered and mounted read-only at `opa.configMountPath` (as `opa.configFileName`), and `--config-file` is appended to generated or custom `opa.args`. A `checksum/opa-config` pod annotation rolls pods on config changes. When `opa.config` is empty and `opa.args` is null, no `args` key is rendered so the image `CMD` is preserved (e.g. seneca-opa baked config).
-  * OPA listens on `127.0.0.1:8181` by default and is never exposed through the Sombra Service.
+  * OPA listens on `:8181` (all interfaces) by default so kubelet probes can reach `/health` via the pod IP, and is never exposed through the Sombra Service. Override `opa.args` and disable probes for strict loopback-only isolation.
   * **Non-breaking change**: OPA is completely opt-in and disabled by default.

--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -93,6 +93,15 @@
 * Added support for Kubernetes Downward API `fieldRef` environment variables via `envs_field_ref`.
   * Supported in both the main Sombra chart and the sombra-job-scheduler subchart.
 
+## 0.12.0
+
+* Added opt-in OPA (Open Policy Agent) sidecar support to the Sombra Deployment.
+  * Gated by `opa.enabled` (default `false`); existing single-container deployments are unchanged.
+  * Configurable `opa.image`, `opa.args`, `opa.env`/`opa.envFrom`, `opa.resources`, `opa.securityContext`, `opa.livenessProbe`/`opa.readinessProbe`/`opa.startupProbe`, `opa.lifecycle` (drain `preStop`), `opa.port`, and supplemental `opa.volumes`/`opa.volumeMounts`.
+  * When `opa.config` is non-empty, a `<fullname>-opa-config` ConfigMap is rendered and mounted read-only at `opa.configMountPath` (as `opa.configFileName`), and `--config-file` is appended to `opa.args`. A `checksum/opa-config` pod annotation rolls pods on config changes. When `opa.config` is empty, no ConfigMap is created and OPA uses the image's bundled base config.
+  * OPA listens on `127.0.0.1:8181` by default and is never exposed through the Sombra Service.
+  * **Non-breaking change**: OPA is completely opt-in and disabled by default.
+
 ## 0.11.0
 
 * Added support for a Kubernetes `startupProbe` on the Sombra container.

--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -93,18 +93,18 @@
 * Added support for Kubernetes Downward API `fieldRef` environment variables via `envs_field_ref`.
   * Supported in both the main Sombra chart and the sombra-job-scheduler subchart.
 
-## 0.12.0
-
-* Added opt-in OPA (Open Policy Agent) sidecar support to the Sombra Deployment.
-  * Gated by `opa.enabled` (default `false`); existing single-container deployments are unchanged.
-  * Configurable `opa.image`, `opa.args`, `opa.env`/`opa.envFrom`, `opa.resources`, `opa.securityContext`, `opa.livenessProbe`/`opa.readinessProbe`/`opa.startupProbe`, `opa.lifecycle` (drain `preStop`), `opa.port`, and supplemental `opa.volumes`/`opa.volumeMounts`.
-  * When `opa.config` is non-empty, a `<fullname>-opa-config` ConfigMap is rendered and mounted read-only at `opa.configMountPath` (as `opa.configFileName`), and `--config-file` is appended to `opa.args`. A `checksum/opa-config` pod annotation rolls pods on config changes. When `opa.config` is empty, no ConfigMap is created and OPA uses the image's bundled base config.
-  * OPA listens on `127.0.0.1:8181` by default and is never exposed through the Sombra Service.
-  * **Non-breaking change**: OPA is completely opt-in and disabled by default.
-
 ## 0.11.0
 
 * Added support for a Kubernetes `startupProbe` on the Sombra container.
   * Defaults to the same `/health` endpoint on port `5042` used by the existing liveness and readiness probes, with a longer `failureThreshold` to accommodate slow start-ups.
   * Configurable via the `startupProbe` field in `values.yaml`. Set `startupProbe: null` to disable it entirely.
   * **Non-breaking change**: existing deployments will pick up the default startup probe; behaviour can be reverted by overriding or disabling the value.
+
+## 0.12.0
+
+* Added opt-in OPA (Open Policy Agent) sidecar support to the Sombra Deployment.
+  * Gated by `opa.enabled` (default `false`); existing single-container deployments are unchanged.
+  * Configurable `opa.image`, `opa.args`, `opa.env`/`opa.envFrom`, `opa.resources`, `opa.securityContext`, `opa.livenessProbe`/`opa.readinessProbe`/`opa.startupProbe`, `opa.lifecycle`, `opa.port`, and supplemental `opa.volumeMounts`.
+  * When `opa.config` is non-empty, a `<fullname>-opa-config` ConfigMap is rendered and mounted read-only at `opa.configMountPath` (as `opa.configFileName`), and `--config-file` is appended to generated or custom `opa.args`. A `checksum/opa-config` pod annotation rolls pods on config changes. When `opa.config` is empty and `opa.args` is null, no `args` key is rendered so the image `CMD` is preserved (e.g. seneca-opa baked config).
+  * OPA listens on `127.0.0.1:8181` by default and is never exposed through the Sombra Service.
+  * **Non-breaking change**: OPA is completely opt-in and disabled by default.

--- a/charts/sombra/Chart.yaml
+++ b/charts/sombra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sombra
 description: A Helm chart to deploy Sombra and its dependent services in a Kubernetes cluster
 type: application
-version: 0.11.0
+version: 0.12.0
 maintainers:
   - name: Transcend
     email: dev@transcend.io

--- a/charts/sombra/templates/deployment.yaml
+++ b/charts/sombra/templates/deployment.yaml
@@ -16,9 +16,15 @@ spec:
       {{- include "sombra-chart.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- $opa := .Values.opa -}}
+      {{- if or .Values.podAnnotations (and $opa.enabled $opa.config) }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if and $opa.enabled $opa.config }}
+        checksum/opa-config: {{ toYaml $opa.config | sha256sum }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "sombra-chart.labels" . | nindent 8 }}
@@ -44,9 +50,18 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.volumes }}
+      {{- $opa := .Values.opa -}}
+      {{- if or .Values.volumes (and $opa.enabled $opa.config) }}
       volumes:
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if and $opa.enabled $opa.config }}
+        - name: opa-config
+          configMap:
+            name: {{ include "sombra-chart.fullname" . }}-opa-config
+            defaultMode: 0444
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -107,6 +122,57 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
+        {{- if $opa.enabled }}
+        - name: opa
+          image: "{{ $opa.image.repository }}:{{ $opa.image.tag }}"
+          imagePullPolicy: {{ $opa.image.pullPolicy }}
+          {{- with $opa.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $opa.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $opa.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            {{- toYaml $opa.args | nindent 12 }}
+            {{- if $opa.config }}
+            - --config-file={{ $opa.configMountPath }}/{{ $opa.configFileName }}
+            {{- end }}
+          ports:
+            - name: opa
+              containerPort: {{ $opa.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml $opa.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml $opa.readinessProbe | nindent 12 }}
+          {{- with $opa.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml $opa.resources | nindent 12 }}
+          {{- with $opa.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or $opa.config $opa.volumeMounts }}
+          volumeMounts:
+            {{- if $opa.config }}
+            - name: opa-config
+              mountPath: {{ $opa.configMountPath }}
+              readOnly: true
+            {{- end }}
+            {{- with $opa.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/sombra/templates/deployment.yaml
+++ b/charts/sombra/templates/deployment.yaml
@@ -50,7 +50,6 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $opa := .Values.opa -}}
       {{- if or .Values.volumes (and $opa.enabled $opa.config) }}
       volumes:
         {{- with .Values.volumes }}
@@ -138,11 +137,19 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if or $opa.args $opa.config }}
           args:
+            {{- if $opa.args }}
             {{- toYaml $opa.args | nindent 12 }}
+            {{- else }}
+            - run
+            - --server
+            - --addr=127.0.0.1:{{ $opa.port }}
+            {{- end }}
             {{- if $opa.config }}
             - --config-file={{ $opa.configMountPath }}/{{ $opa.configFileName }}
             {{- end }}
+          {{- end }}
           ports:
             - name: opa
               containerPort: {{ $opa.port }}

--- a/charts/sombra/templates/deployment.yaml
+++ b/charts/sombra/templates/deployment.yaml
@@ -144,7 +144,7 @@ spec:
             {{- else }}
             - run
             - --server
-            - --addr=127.0.0.1:{{ $opa.port }}
+            - --addr=:{{ $opa.port }}
             {{- end }}
             {{- if $opa.config }}
             - --config-file={{ $opa.configMountPath }}/{{ $opa.configFileName }}

--- a/charts/sombra/templates/opa-configmap.yaml
+++ b/charts/sombra/templates/opa-configmap.yaml
@@ -1,0 +1,13 @@
+{{- $opa := .Values.opa -}}
+{{- if and $opa.enabled $opa.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sombra-chart.fullname" . }}-opa-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "sombra-chart.labels" . | nindent 4 }}
+data:
+  {{ $opa.configFileName }}: |
+    {{- toYaml $opa.config | nindent 4 }}
+{{- end }}

--- a/charts/sombra/tests/deployment_test.yaml
+++ b/charts/sombra/tests/deployment_test.yaml
@@ -295,7 +295,7 @@ tests:
           content: --server
       - contains:
           path: spec.template.spec.containers[1].args
-          content: --addr=127.0.0.1:8181
+          content: --addr=:8181
       - contains:
           path: spec.template.spec.containers[1].args
           content: --config-file=/opa/config/opa-config.yaml
@@ -396,7 +396,7 @@ tests:
             configMapRef:
               name: opa-extra
 
-  - it: should generate loopback args from opa.port when config is set and args are null
+  - it: should generate server args from opa.port when config is set and args are null
     set:
       namespace: test-ns
       opa:
@@ -413,7 +413,7 @@ tests:
           value:
             - run
             - --server
-            - --addr=127.0.0.1:9191
+            - --addr=:9191
             - --config-file=/opa/config/opa-config.yaml
       - equal:
           path: spec.template.spec.containers[1].ports[0].containerPort

--- a/charts/sombra/tests/deployment_test.yaml
+++ b/charts/sombra/tests/deployment_test.yaml
@@ -310,10 +310,10 @@ tests:
           value: /health
       - equal:
           path: spec.template.spec.containers[1].readinessProbe.httpGet.port
-          value: 8181
+          value: opa
       - equal:
           path: spec.template.spec.containers[1].startupProbe.httpGet.port
-          value: 8181
+          value: opa
       - equal:
           path: spec.template.spec.containers[1].resources
           value:
@@ -323,12 +323,8 @@ tests:
             requests:
               cpu: 50m
               memory: 64Mi
-      - equal:
-          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command
-          value:
-            - /bin/sh
-            - -c
-            - sleep 5
+      - notExists:
+          path: spec.template.spec.containers[1].lifecycle
       - contains:
           path: spec.template.spec.containers[1].volumeMounts
           content:
@@ -345,7 +341,7 @@ tests:
       - exists:
           path: spec.template.metadata.annotations["checksum/opa-config"]
 
-  - it: should render OPA without config-file or config volume when config is empty
+  - it: should render OPA without args when config and args are empty
     set:
       namespace: test-ns
       opa:
@@ -356,9 +352,8 @@ tests:
       - lengthEqual:
           path: spec.template.spec.containers
           count: 2
-      - notContains:
+      - notExists:
           path: spec.template.spec.containers[1].args
-          content: --config-file=/opa/config/opa-config.yaml
       - notExists:
           path: spec.template.spec.containers[1].volumeMounts
       - notExists:
@@ -400,3 +395,26 @@ tests:
           content:
             configMapRef:
               name: opa-extra
+
+  - it: should generate loopback args from opa.port when config is set and args are null
+    set:
+      namespace: test-ns
+      opa:
+        enabled: true
+        port: 9191
+        config:
+          decision_logs:
+            console: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[1].args
+          value:
+            - run
+            - --server
+            - --addr=127.0.0.1:9191
+            - --config-file=/opa/config/opa-config.yaml
+      - equal:
+          path: spec.template.spec.containers[1].ports[0].containerPort
+          value: 9191

--- a/charts/sombra/tests/deployment_test.yaml
+++ b/charts/sombra/tests/deployment_test.yaml
@@ -239,3 +239,164 @@ tests:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+
+  - it: should not render the OPA sidecar by default
+    set:
+      namespace: test-ns
+    asserts:
+      - isKind:
+          of: Deployment
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: sombra
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: should render the OPA sidecar when enabled with config
+    set:
+      namespace: test-ns
+      opa:
+        enabled: true
+        config:
+          services:
+            bundle_service:
+              url: http://127.0.0.1:5042
+          bundles:
+            seneca:
+              service: bundle_service
+              resource: /seneca/bundles/active
+          decision_logs:
+            console: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: opa
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: openpolicyagent/opa:0.70.0-static
+      - equal:
+          path: spec.template.spec.containers[1].imagePullPolicy
+          value: IfNotPresent
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: run
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --server
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --addr=127.0.0.1:8181
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --config-file=/opa/config/opa-config.yaml
+      - equal:
+          path: spec.template.spec.containers[1].ports[0]
+          value:
+            name: opa
+            containerPort: 8181
+            protocol: TCP
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: 8181
+      - equal:
+          path: spec.template.spec.containers[1].startupProbe.httpGet.port
+          value: 8181
+      - equal:
+          path: spec.template.spec.containers[1].resources
+          value:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command
+          value:
+            - /bin/sh
+            - -c
+            - sleep 5
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: opa-config
+            mountPath: /opa/config
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: opa-config
+            configMap:
+              name: testing-sombra-opa-config
+              defaultMode: 0444
+      - exists:
+          path: spec.template.metadata.annotations["checksum/opa-config"]
+
+  - it: should render OPA without config-file or config volume when config is empty
+    set:
+      namespace: test-ns
+      opa:
+        enabled: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+      - notContains:
+          path: spec.template.spec.containers[1].args
+          content: --config-file=/opa/config/opa-config.yaml
+      - notExists:
+          path: spec.template.spec.containers[1].volumeMounts
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: should render OPA env and args overrides
+    set:
+      namespace: test-ns
+      opa:
+        enabled: true
+        args:
+          - run
+          - --server
+          - --addr=127.0.0.1:9191
+        env:
+          - name: SENECA_BUNDLE_PROXY_URL
+            value: http://127.0.0.1:5042
+        envFrom:
+          - configMapRef:
+              name: opa-extra
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[1].args
+          value:
+            - run
+            - --server
+            - --addr=127.0.0.1:9191
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: SENECA_BUNDLE_PROXY_URL
+            value: http://127.0.0.1:5042
+      - contains:
+          path: spec.template.spec.containers[1].envFrom
+          content:
+            configMapRef:
+              name: opa-extra

--- a/charts/sombra/tests/opa_configmap_test.yaml
+++ b/charts/sombra/tests/opa_configmap_test.yaml
@@ -1,0 +1,91 @@
+# Docs: https://github.com/helm-unittest/helm-unittest/blob/main/DOCUMENT.md
+suite: OPA ConfigMap
+templates:
+  - opa-configmap.yaml
+release:
+  name: testing
+tests:
+  - it: should not render a ConfigMap when OPA is disabled
+    set:
+      namespace: test-ns
+      opa:
+        enabled: false
+        config:
+          services:
+            bundle_service:
+              url: http://127.0.0.1:5042
+    asserts:
+      - notExists:
+          path: kind
+
+  - it: should not render a ConfigMap when enabled but config is empty
+    set:
+      namespace: test-ns
+      opa:
+        enabled: true
+        config: {}
+    asserts:
+      - notExists:
+          path: kind
+
+  - it: should render the ConfigMap when enabled with config
+    set:
+      namespace: test-ns
+      opa:
+        enabled: true
+        config:
+          services:
+            bundle_service:
+              url: http://127.0.0.1:5042
+          bundles:
+            seneca:
+              service: bundle_service
+              resource: /seneca/bundles/active
+              polling:
+                min_delay_seconds: 10
+                max_delay_seconds: 30
+          decision_logs:
+            console: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: testing-sombra-opa-config
+      - equal:
+          path: metadata.namespace
+          value: test-ns
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/name: sombra
+            app.kubernetes.io/instance: testing
+      - exists:
+          path: data["opa-config.yaml"]
+      - matchRegex:
+          path: data["opa-config.yaml"]
+          pattern: "services:"
+      - matchRegex:
+          path: data["opa-config.yaml"]
+          pattern: "bundle_service:"
+      - matchRegex:
+          path: data["opa-config.yaml"]
+          pattern: "/seneca/bundles/active"
+      - matchRegex:
+          path: data["opa-config.yaml"]
+          pattern: "decision_logs:"
+
+  - it: should honor a custom config file name
+    set:
+      namespace: test-ns
+      opa:
+        enabled: true
+        configFileName: custom-opa.yaml
+        config:
+          decision_logs:
+            console: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - exists:
+          path: data["custom-opa.yaml"]

--- a/charts/sombra/tests/service_test.yaml
+++ b/charts/sombra/tests/service_test.yaml
@@ -1,0 +1,35 @@
+# Docs: https://github.com/helm-unittest/helm-unittest/blob/main/DOCUMENT.md
+suite: Service
+templates:
+  - service.yaml
+release:
+  name: testing
+tests:
+  - it: should not expose the OPA port on either Service
+    set:
+      namespace: test-ns
+      opa:
+        enabled: true
+        port: 8181
+        config:
+          decision_logs:
+            console: true
+    asserts:
+      - equal:
+          path: kind
+          value: Service
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+      - notContains:
+          path: spec.ports
+          content:
+            port: 8181
+      - notContains:
+          path: spec.ports
+          content:
+            targetPort: opa
+      - notContains:
+          path: spec.ports
+          content:
+            name: opa

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -270,17 +270,17 @@ opa:
   enabled: false
 
   image:
+    # Transcend EKS deploys should override repository/tag to the internal
+    # seneca-opa image (LINK-7473); this default is for generic chart use.
     repository: openpolicyagent/opa
     tag: "0.70.0-static"
     pullPolicy: IfNotPresent
 
-  # Arguments passed to the OPA entrypoint. The `--config-file` flag is
-  # appended automatically when `config` is non-empty, so the default value
-  # only needs to start the server bound to the loopback interface.
-  args:
-    - run
-    - --server
-    - --addr=127.0.0.1:8181
+  # Replaces image CMD when non-null. Omit (null) to use the image entrypoint —
+  # required for images with baked-in config (e.g. seneca-opa). When `config`
+  # is non-empty and `args` is null, the chart generates loopback-safe defaults
+  # and appends `--config-file`. When both are empty, no `args` key is rendered.
+  args: null
 
   # Environment variables for the OPA container.
   env: []
@@ -289,6 +289,9 @@ opa:
   envFrom: []
 
   # Container port OPA listens on. Kept pod-local; not exposed by a Service.
+  # Probes target the named port `opa`. When `args` is null and `config` is set,
+  # the chart generates `--addr=127.0.0.1:<port>`. Override `args` manually to
+  # keep `--addr` in sync when changing this value.
   port: 8181
 
   # Resource requests and limits for the OPA container. Defaults are
@@ -304,11 +307,11 @@ opa:
   # Container-level security context.
   securityContext: {}
 
-  # Health probes against OPA's `/health` endpoint on the loopback port.
+  # Health probes against OPA's `/health` endpoint on the named port `opa`.
   livenessProbe:
     httpGet:
       path: /health
-      port: 8181
+      port: opa
       scheme: HTTP
     initialDelaySeconds: 10
     timeoutSeconds: 5
@@ -318,7 +321,7 @@ opa:
   readinessProbe:
     httpGet:
       path: /health
-      port: 8181
+      port: opa
       scheme: HTTP
     initialDelaySeconds: 5
     timeoutSeconds: 5
@@ -330,7 +333,7 @@ opa:
   startupProbe:
     httpGet:
       path: /health
-      port: 8181
+      port: opa
       scheme: HTTP
     initialDelaySeconds: 5
     timeoutSeconds: 5
@@ -338,26 +341,19 @@ opa:
     successThreshold: 1
     periodSeconds: 10
 
-  # Graceful shutdown: `preStop` sleep lets Sombra drain in-flight requests
-  # before OPA receives SIGTERM.
-  lifecycle:
-    preStop:
-      exec:
-        command:
-          - /bin/sh
-          - -c
-          - sleep 5
+  # Optional lifecycle hooks. Default empty: static/distroless OPA images
+  # have no shell, so a `/bin/sh` preStop would fail on every shutdown.
+  lifecycle: {}
 
   # OPA configuration. When non-empty, a ConfigMap named
   # `<fullname>-opa-config` is rendered and mounted read-only at
   # `configMountPath` (as `configFileName`), and `--config-file` is appended
-  # to `args`. When empty, OPA uses the image's bundled base config and no
-  # ConfigMap is created.
+  # to `args`. When empty, no ConfigMap is created — ensure `args` still
+  # point at any image-bundled config (container `args` replace image `CMD`).
   config: {}
   configMountPath: /opa/config
   configFileName: opa-config.yaml
 
-  # Supplemental volumes / volumeMounts for the OPA container, in addition
-  # to the optional config mount above.
-  volumes: []
+  # Supplemental volumeMounts for the OPA container (in addition to the
+  # optional config mount). Mount targets must exist under pod `volumes`.
   volumeMounts: []

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -261,9 +261,12 @@ job-scheduler:
   enabled: false
 
 # Opt-in OPA (Open Policy Agent) sidecar.
-# When enabled, an `opa` container runs alongside Sombra in the same pod and
-# is reachable only over localhost (default port 8181). It is never exposed
-# through the Sombra Service; Sombra reaches it via `http://127.0.0.1:<port>`.
+# When enabled, an `opa` container runs alongside Sombra in the same pod. It is
+# never exposed through the Sombra Service; Sombra reaches it over the pod
+# network at `http://127.0.0.1:<port>` (or the pod IP). The generated default
+# `--addr` binds all interfaces so kubelet probes (which dial the pod IP) can
+# reach `/health`; override `opa.args` and disable probes if you require
+# strict loopback-only isolation.
 opa:
   # Set to true to render the OPA sidecar container and (when `config` is
   # non-empty) its ConfigMap.
@@ -278,8 +281,9 @@ opa:
 
   # Replaces image CMD when non-null. Omit (null) to use the image entrypoint —
   # required for images with baked-in config (e.g. seneca-opa). When `config`
-  # is non-empty and `args` is null, the chart generates loopback-safe defaults
-  # and appends `--config-file`. When both are empty, no `args` key is rendered.
+  # is non-empty and `args` is null, the chart generates server defaults bound
+  # to all interfaces (so kubelet probes via the pod IP succeed) and appends
+  # `--config-file`. When both are empty, no `args` key is rendered.
   args: null
 
   # Environment variables for the OPA container.

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -271,7 +271,7 @@ opa:
 
   image:
     # Transcend EKS deploys should override repository/tag to the internal
-    # seneca-opa image (LINK-7473); this default is for generic chart use.
+    # seneca-opa image; this default is for generic chart use.
     repository: openpolicyagent/opa
     tag: "0.70.0-static"
     pullPolicy: IfNotPresent

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -259,3 +259,105 @@ pathfinder:
 # Asynchronous Sombra Job Scheduler
 job-scheduler:
   enabled: false
+
+# Opt-in OPA (Open Policy Agent) sidecar.
+# When enabled, an `opa` container runs alongside Sombra in the same pod and
+# is reachable only over localhost (default port 8181). It is never exposed
+# through the Sombra Service; Sombra reaches it via `http://127.0.0.1:<port>`.
+opa:
+  # Set to true to render the OPA sidecar container and (when `config` is
+  # non-empty) its ConfigMap.
+  enabled: false
+
+  image:
+    repository: openpolicyagent/opa
+    tag: "0.70.0-static"
+    pullPolicy: IfNotPresent
+
+  # Arguments passed to the OPA entrypoint. The `--config-file` flag is
+  # appended automatically when `config` is non-empty, so the default value
+  # only needs to start the server bound to the loopback interface.
+  args:
+    - run
+    - --server
+    - --addr=127.0.0.1:8181
+
+  # Environment variables for the OPA container.
+  env: []
+  # Load environment variables from ConfigMaps/Secrets, same shape as
+  # `envFrom` on the Sombra container.
+  envFrom: []
+
+  # Container port OPA listens on. Kept pod-local; not exposed by a Service.
+  port: 8181
+
+  # Resource requests and limits for the OPA container. Defaults are
+  # intentionally conservative; tune from load-test data.
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+    limits:
+      cpu: "100m"
+      memory: "128Mi"
+
+  # Container-level security context.
+  securityContext: {}
+
+  # Health probes against OPA's `/health` endpoint on the loopback port.
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 8181
+      scheme: HTTP
+    initialDelaySeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+    periodSeconds: 10
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 8181
+      scheme: HTTP
+    initialDelaySeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+    periodSeconds: 10
+  # Startup probe gives OPA additional time to come up before liveness and
+  # readiness probes begin running. Set `startupProbe: null` to disable.
+  startupProbe:
+    httpGet:
+      path: /health
+      port: 8181
+      scheme: HTTP
+    initialDelaySeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 30
+    successThreshold: 1
+    periodSeconds: 10
+
+  # Graceful shutdown: `preStop` sleep lets Sombra drain in-flight requests
+  # before OPA receives SIGTERM.
+  lifecycle:
+    preStop:
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - sleep 5
+
+  # OPA configuration. When non-empty, a ConfigMap named
+  # `<fullname>-opa-config` is rendered and mounted read-only at
+  # `configMountPath` (as `configFileName`), and `--config-file` is appended
+  # to `args`. When empty, OPA uses the image's bundled base config and no
+  # ConfigMap is created.
+  config: {}
+  configMountPath: /opa/config
+  configFileName: opa-config.yaml
+
+  # Supplemental volumes / volumeMounts for the OPA container, in addition
+  # to the optional config mount above.
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
## Summary
- Add disabled-by-default `opa.*` values and a conditional OPA sidecar container in the Sombra Deployment (image, args, env, probes, resources, lifecycle, optional config mount).
- Render an optional OPA ConfigMap only when `opa.config` is set; leave the Service unchanged so port `8181` stays pod-local (no NetworkPolicy).
- Bump the chart to `0.12.0` with changelog and Helm unit tests for disabled/enabled rendering, config mount, and no Service exposure of `8181`.

Fixes LINK-7476.

## Test plan
- [x] `helm lint charts/sombra`
- [x] `helm unittest charts/sombra` (disabled/enabled sidecar, ConfigMap, Service port assertions)
- [ ] `helm template` with `opa.enabled=false` → single container, no OPA ConfigMap
- [ ] `helm template` with `opa.enabled=true` and nonempty `opa.config` → two containers, ConfigMap + config mount, `--config-file` arg, no Service port `8181`
- [ ] After merge/release, confirm chart `0.12.0` is available for LINK-7473 rollout wiring


Made with [Cursor](https://cursor.com)