### PR TITLE
Make OPA sidecar non-blocking for Sombra pod readiness

### DIFF
--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -108,3 +108,9 @@
   * When `opa.config` is non-empty, a `<fullname>-opa-config` ConfigMap is rendered and mounted read-only at `opa.configMountPath` (as `opa.configFileName`), and `--config-file` is appended to generated or custom `opa.args`. A `checksum/opa-config` pod annotation rolls pods on config changes. When `opa.config` is empty and `opa.args` is null, no `args` key is rendered so the image `CMD` is preserved (e.g. seneca-opa baked config).
   * OPA listens on `:8181` (all interfaces) by default so kubelet probes can reach `/health` via the pod IP, and is never exposed through the Sombra Service. Override `opa.args` and disable probes for strict loopback-only isolation.
   * **Non-breaking change**: OPA is completely opt-in and disabled by default.
+
+## 0.13.0
+
+* Made OPA `livenessProbe` and `readinessProbe` omitable via `null`, matching the existing `startupProbe` pattern. Setting `opa.readinessProbe: null` no longer renders invalid `readinessProbe: null` YAML.
+  * **ECS vs EKS failure-mode parity**: On ECS MTS, OPA runs with `essential=false`, so an OPA crash leaves Sombra in service and Seneca fails closed in-app. On EKS, any container readiness probe gates pod Ready; omit OPA readiness (`opa.readinessProbe: null`) so OPA outages do not drain Sombra from Service/ALB endpoints. Keep OPA liveness (default) to restart a wedged sidecar.
+  * **Non-breaking change**: default OPA probes are unchanged; existing installs keep current behavior unless consumers explicitly set probes to `null`.

--- a/charts/sombra/Chart.yaml
+++ b/charts/sombra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sombra
 description: A Helm chart to deploy Sombra and its dependent services in a Kubernetes cluster
 type: application
-version: 0.12.0
+version: 0.13.0
 maintainers:
   - name: Transcend
     email: dev@transcend.io

--- a/charts/sombra/templates/deployment.yaml
+++ b/charts/sombra/templates/deployment.yaml
@@ -154,10 +154,14 @@ spec:
             - name: opa
               containerPort: {{ $opa.port }}
               protocol: TCP
+          {{- with $opa.livenessProbe }}
           livenessProbe:
-            {{- toYaml $opa.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $opa.readinessProbe }}
           readinessProbe:
-            {{- toYaml $opa.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with $opa.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/sombra/tests/deployment_test.yaml
+++ b/charts/sombra/tests/deployment_test.yaml
@@ -418,3 +418,33 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].ports[0].containerPort
           value: 9191
+
+  - it: should not render OPA readinessProbe when disabled
+    set:
+      namespace: test-ns
+      opa:
+        enabled: true
+        readinessProbe: null
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.containers[1].readinessProbe
+      - exists:
+          path: spec.template.spec.containers[0].readinessProbe
+      - exists:
+          path: spec.template.spec.containers[1].livenessProbe
+
+  - it: should not render OPA livenessProbe when disabled
+    set:
+      namespace: test-ns
+      opa:
+        enabled: true
+        livenessProbe: null
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.containers[1].livenessProbe
+      - exists:
+          path: spec.template.spec.containers[1].readinessProbe

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -312,7 +312,7 @@ opa:
   securityContext: {}
 
   # Health probes against OPA's `/health` endpoint on the named port `opa`.
-  # Set any probe to `null` to omit it (same pattern as `startupProbe`).
+  # Set any probe to `null` to omit it.
   livenessProbe:
     httpGet:
       path: /health
@@ -334,7 +334,7 @@ opa:
     successThreshold: 1
     periodSeconds: 10
   # Startup probe gives OPA additional time to come up before liveness and
-  # readiness probes begin running. Set `startupProbe: null` to disable.
+  # readiness probes begin running. Any probe can be omitted via `null`.
   startupProbe:
     httpGet:
       path: /health

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -312,6 +312,7 @@ opa:
   securityContext: {}
 
   # Health probes against OPA's `/health` endpoint on the named port `opa`.
+  # Set any probe to `null` to omit it (same pattern as `startupProbe`).
   livenessProbe:
     httpGet:
       path: /health


### PR DESCRIPTION
## Summary
- Make `opa.livenessProbe` and `opa.readinessProbe` omitable via `null` (same pattern as `opa.startupProbe`), fixing invalid `readinessProbe: null` YAML from Pulumi consumers.
- Document ECS MTS `essential=false` vs EKS failure-mode parity in the changelog (Transcend ST deploys should set `opa.readinessProbe: null` so OPA outages fail closed in Sombra without draining the pod from Service/ALB endpoints; keep liveness to restart wedged OPA). Deployer notes are in the PR review thread.
- Bump chart to `0.13.0` with changelog; default OPA probes unchanged for generic chart users.

Fixes LINK-7493. Unblocks LINK-7473 / transcend-io/main#46310.

## Test plan
- [x] `helm lint charts/sombra`
- [x] `helm unittest charts/sombra` (21/21 pass)
- [x] OPA enabled + `readinessProbe: null` → no OPA readinessProbe; Sombra readinessProbe preserved
- [x] OPA enabled + `livenessProbe: null` → no OPA livenessProbe; readinessProbe preserved
- [x] Existing OPA-enabled-with-config test still renders default probes
- [ ] After release, LINK-7473 can set `opa.readinessProbe: null` from Pulumi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm template-only change with unchanged defaults; risk is limited to deploys that explicitly set OPA probes to `null`, which is the intended operational knob.
> 
> **Overview**
> Bumps the **sombra** chart to **0.13.0** and changes the OPA sidecar template so `opa.livenessProbe` and `opa.readinessProbe` can be disabled with `null`, matching `opa.startupProbe`. Previously, setting a probe to `null` could emit invalid `readinessProbe: null` in the Deployment manifest (e.g. from Pulumi).
> 
> With OPA enabled, consumers can set **`opa.readinessProbe: null`** so a failing OPA sidecar does not block pod Ready and drain Sombra from Service/ALB endpoints—aligned with ECS MTS behavior where OPA is non-essential—while keeping default liveness to restart a wedged OPA. Default probe values are unchanged unless explicitly nulled.
> 
> Adds helm-unittest coverage for omitted OPA liveness/readiness probes and documents the behavior in the changelog and `values.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c857bc2090f03973e49f66d9d5a6509b515d153d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->