### PR TITLE
Raise default OPA sidecar resources to match ECS opa-mts (0.14.0)

### DIFF
--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -2,115 +2,124 @@
 
 ## 0.1.0
 
-* Initial version
+- Initial version
 
 ## 0.2.0
 
-* Chart fixes
+- Chart fixes
 
 ## 0.2.1
 
-* Chart fixes
+- Chart fixes
 
 ## 0.3.0
 
-* TLS support llm-classifier
+- TLS support llm-classifier
 
 ## 0.3.1
-* Update docs
-* Remove old helm packages
+
+- Update docs
+- Remove old helm packages
 
 ## 0.4.0
-* Repo name change
+
+- Repo name change
 
 ## 0.5.0
-* Repo structure change
+
+- Repo structure change
 
 ## 0.6.0
 
-* Allow for more advanced Sombra configurations to be deployed.
-* Allow for external metrics to be used with the Sombra HPA.
-* Allow for Datadog `DD_SERVICE_NAME` environment variable to be customizable.
-* Ignore generating a `.dockerconfigjson` if `imagePullSecrets`.`enabled` is set to false.
-* Fix typos.
+- Allow for more advanced Sombra configurations to be deployed.
+- Allow for external metrics to be used with the Sombra HPA.
+- Allow for Datadog `DD_SERVICE_NAME` environment variable to be customizable.
+- Ignore generating a `.dockerconfigjson` if `imagePullSecrets`.`enabled` is set to false.
+- Fix typos.
 
 ## 0.6.1
 
-* Fix the issue with the `isMultiTenant` parameter by converting it to a string before using it.
+- Fix the issue with the `isMultiTenant` parameter by converting it to a string before using it.
 
 ## 0.6.2
 
-* Fix issue with external metrics resolution for Sombras Horizontal Pod Autoscaler.
+- Fix issue with external metrics resolution for Sombras Horizontal Pod Autoscaler.
 
 ## 0.6.3
 
-* Fixed a bug with the `secrets.yaml` template, which was causing this error during `helm install`: "Secret in version "v1" cannot be handled as a Secret: json: cannot unmarshal string into Go struct field Secret.data of type map[string][]uint8"
+- Fixed a bug with the `secrets.yaml` template, which was causing this error during `helm install`: "Secret in version "v1" cannot be handled as a Secret: json: cannot unmarshal string into Go struct field Secret.data of type map[string][]uint8"
 
 ## 0.6.4
 
-* Added support for specifying an optional service account name in the chart's values
-  * Added optional serviceAccount configuration section (commented out by default)
-  * Created serviceaccount.yaml template for conditional service account creation
-  * Updated deployment to conditionally use the specified service account
-  * **Non-breaking change**: Service account functionality is completely opt-in and disabled by default
+- Added support for specifying an optional service account name in the chart's values
+  - Added optional serviceAccount configuration section (commented out by default)
+  - Created serviceaccount.yaml template for conditional service account creation
+  - Updated deployment to conditionally use the specified service account
+  - **Non-breaking change**: Service account functionality is completely opt-in and disabled by default
 
 ## 0.6.5
 
-* Added support for client-managed secrets via `envFrom` configuration
-  * Allow loading environment variables from ConfigMaps and Secrets using the `envFrom` field
-  * **Non-breaking change**: `envFrom` functionality is completely opt-in and disabled by default
+- Added support for client-managed secrets via `envFrom` configuration
+  - Allow loading environment variables from ConfigMaps and Secrets using the `envFrom` field
+  - **Non-breaking change**: `envFrom` functionality is completely opt-in and disabled by default
 
 ## 0.6.6
 
-* Added support for pod-level and container-level [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) configuration
-  * Allow users to configure security contexts for enhanced security and compliance
-  * Added `podSecurityContext` and `containerSecurityContext` options in values.yaml for all charts (sombra, llm-classifier, pathfinder)
-  * **Non-breaking change**: Security context functionality is completely opt-in and disabled by default
+- Added support for pod-level and container-level [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) configuration
+  - Allow users to configure security contexts for enhanced security and compliance
+  - Added `podSecurityContext` and `containerSecurityContext` options in values.yaml for all charts (sombra, llm-classifier, pathfinder)
+  - **Non-breaking change**: Security context functionality is completely opt-in and disabled by default
 
 ## 0.6.7
 
-* See 0.6.6. This is a re-release of 0.6.6 to test an updated chart release process.
+- See 0.6.6. This is a re-release of 0.6.6 to test an updated chart release process.
 
 ## 0.6.8
 
-* Added support for host-aliases, and volume mounts to the Sombra customer-ingress pods.
+- Added support for host-aliases, and volume mounts to the Sombra customer-ingress pods.
 
 ## 0.7.0
 
-* Added support for specifying a custom termination grace period for Sombra pods.
+- Added support for specifying a custom termination grace period for Sombra pods.
 
 ## 0.8.0
 
-* Increase default memory and cpu allocation to prevent pod termination.
-* Relax `liveness` and `readiness` probe to prevent pod termination. 
+- Increase default memory and cpu allocation to prevent pod termination.
+- Relax `liveness` and `readiness` probe to prevent pod termination.
 
 ## 0.9.0
 
-* Added support for Asynchronous Sombra Job Scheduler.
+- Added support for Asynchronous Sombra Job Scheduler.
 
 ## 0.10.0
 
-* Added support for Kubernetes Downward API `fieldRef` environment variables via `envs_field_ref`.
-  * Supported in both the main Sombra chart and the sombra-job-scheduler subchart.
+- Added support for Kubernetes Downward API `fieldRef` environment variables via `envs_field_ref`.
+  - Supported in both the main Sombra chart and the sombra-job-scheduler subchart.
 
 ## 0.11.0
 
-* Added support for a Kubernetes `startupProbe` on the Sombra container.
-  * Defaults to the same `/health` endpoint on port `5042` used by the existing liveness and readiness probes, with a longer `failureThreshold` to accommodate slow start-ups.
-  * Configurable via the `startupProbe` field in `values.yaml`. Set `startupProbe: null` to disable it entirely.
-  * **Non-breaking change**: existing deployments will pick up the default startup probe; behaviour can be reverted by overriding or disabling the value.
+- Added support for a Kubernetes `startupProbe` on the Sombra container.
+  - Defaults to the same `/health` endpoint on port `5042` used by the existing liveness and readiness probes, with a longer `failureThreshold` to accommodate slow start-ups.
+  - Configurable via the `startupProbe` field in `values.yaml`. Set `startupProbe: null` to disable it entirely.
+  - **Non-breaking change**: existing deployments will pick up the default startup probe; behaviour can be reverted by overriding or disabling the value.
 
 ## 0.12.0
 
-* Added opt-in OPA (Open Policy Agent) sidecar support to the Sombra Deployment.
-  * Gated by `opa.enabled` (default `false`); existing single-container deployments are unchanged.
-  * Configurable `opa.image`, `opa.args`, `opa.env`/`opa.envFrom`, `opa.resources`, `opa.securityContext`, `opa.livenessProbe`/`opa.readinessProbe`/`opa.startupProbe`, `opa.lifecycle`, `opa.port`, and supplemental `opa.volumeMounts`.
-  * When `opa.config` is non-empty, a `<fullname>-opa-config` ConfigMap is rendered and mounted read-only at `opa.configMountPath` (as `opa.configFileName`), and `--config-file` is appended to generated or custom `opa.args`. A `checksum/opa-config` pod annotation rolls pods on config changes. When `opa.config` is empty and `opa.args` is null, no `args` key is rendered so the image `CMD` is preserved (e.g. seneca-opa baked config).
-  * OPA listens on `:8181` (all interfaces) by default so kubelet probes can reach `/health` via the pod IP, and is never exposed through the Sombra Service. Override `opa.args` and disable probes for strict loopback-only isolation.
-  * **Non-breaking change**: OPA is completely opt-in and disabled by default.
+- Added opt-in OPA (Open Policy Agent) sidecar support to the Sombra Deployment.
+  - Gated by `opa.enabled` (default `false`); existing single-container deployments are unchanged.
+  - Configurable `opa.image`, `opa.args`, `opa.env`/`opa.envFrom`, `opa.resources`, `opa.securityContext`, `opa.livenessProbe`/`opa.readinessProbe`/`opa.startupProbe`, `opa.lifecycle`, `opa.port`, and supplemental `opa.volumeMounts`.
+  - When `opa.config` is non-empty, a `<fullname>-opa-config` ConfigMap is rendered and mounted read-only at `opa.configMountPath` (as `opa.configFileName`), and `--config-file` is appended to generated or custom `opa.args`. A `checksum/opa-config` pod annotation rolls pods on config changes. When `opa.config` is empty and `opa.args` is null, no `args` key is rendered so the image `CMD` is preserved (e.g. seneca-opa baked config).
+  - OPA listens on `:8181` (all interfaces) by default so kubelet probes can reach `/health` via the pod IP, and is never exposed through the Sombra Service. Override `opa.args` and disable probes for strict loopback-only isolation.
+  - **Non-breaking change**: OPA is completely opt-in and disabled by default.
 
 ## 0.13.0
 
-* Made OPA `livenessProbe` and `readinessProbe` omitable via `null`, matching the existing `startupProbe` pattern. Setting `opa.readinessProbe: null` no longer renders invalid `readinessProbe: null` YAML.
-  * **ECS vs EKS failure-mode parity**: On ECS MTS, OPA runs with `essential=false`, so an OPA crash leaves Sombra in service and Seneca fails closed in-app. On EKS, any container readiness probe gates pod Ready; omit OPA readiness (`opa.readinessProbe: null`) so OPA outages do not drain Sombra from Service/ALB endpoints. Keep OPA liveness (default) to restart a wedged sidecar.
-  * **Non-breaking change**: default OPA probes are unchanged; existing installs keep current behavior unless consumers explicitly set probes to `null`.
+- Made OPA `livenessProbe` and `readinessProbe` omitable via `null`, matching the existing `startupProbe` pattern. Setting `opa.readinessProbe: null` no longer renders invalid `readinessProbe: null` YAML.
+  - **ECS vs EKS failure-mode parity**: On ECS MTS, OPA runs with `essential=false`, so an OPA crash leaves Sombra in service and Seneca fails closed in-app. On EKS, any container readiness probe gates pod Ready; omit OPA readiness (`opa.readinessProbe: null`) so OPA outages do not drain Sombra from Service/ALB endpoints. Keep OPA liveness (default) to restart a wedged sidecar.
+  - **Non-breaking change**: default OPA probes are unchanged; existing installs keep current behavior unless consumers explicitly set probes to `null`.
+
+## 0.14.0
+
+- Raised default `opa.resources` so the OPA sidecar matches the ECS `opa-mts` Fargate reservation and can burst.
+  - Requests `50m/64Mi` → `250m/512Mi` (matches ECS `opa-mts` `cpu=256`/`memory=512`); limits `100m/128Mi` → `500m/1Gi` (2x headroom). The previous defaults made `requests` exceed `limits` once consumers bumped requests to `250m/512Mi`, which Kubernetes rejects.
+  - **Behavior change for opt-in OPA consumers**: deployments with `opa.enabled: true` and no `opa.resources` override now reserve more CPU/memory. Self-hosted consumers that pinned the old defaults should set `opa.resources` explicitly.

--- a/charts/sombra/CHANGELOG.md
+++ b/charts/sombra/CHANGELOG.md
@@ -2,124 +2,121 @@
 
 ## 0.1.0
 
-- Initial version
+* Initial version
 
 ## 0.2.0
 
-- Chart fixes
+* Chart fixes
 
 ## 0.2.1
 
-- Chart fixes
+* Chart fixes
 
 ## 0.3.0
 
-- TLS support llm-classifier
+* TLS support llm-classifier
 
 ## 0.3.1
-
-- Update docs
-- Remove old helm packages
+* Update docs
+* Remove old helm packages
 
 ## 0.4.0
-
-- Repo name change
+* Repo name change
 
 ## 0.5.0
-
-- Repo structure change
+* Repo structure change
 
 ## 0.6.0
 
-- Allow for more advanced Sombra configurations to be deployed.
-- Allow for external metrics to be used with the Sombra HPA.
-- Allow for Datadog `DD_SERVICE_NAME` environment variable to be customizable.
-- Ignore generating a `.dockerconfigjson` if `imagePullSecrets`.`enabled` is set to false.
-- Fix typos.
+* Allow for more advanced Sombra configurations to be deployed.
+* Allow for external metrics to be used with the Sombra HPA.
+* Allow for Datadog `DD_SERVICE_NAME` environment variable to be customizable.
+* Ignore generating a `.dockerconfigjson` if `imagePullSecrets`.`enabled` is set to false.
+* Fix typos.
 
 ## 0.6.1
 
-- Fix the issue with the `isMultiTenant` parameter by converting it to a string before using it.
+* Fix the issue with the `isMultiTenant` parameter by converting it to a string before using it.
 
 ## 0.6.2
 
-- Fix issue with external metrics resolution for Sombras Horizontal Pod Autoscaler.
+* Fix issue with external metrics resolution for Sombras Horizontal Pod Autoscaler.
 
 ## 0.6.3
 
-- Fixed a bug with the `secrets.yaml` template, which was causing this error during `helm install`: "Secret in version "v1" cannot be handled as a Secret: json: cannot unmarshal string into Go struct field Secret.data of type map[string][]uint8"
+* Fixed a bug with the `secrets.yaml` template, which was causing this error during `helm install`: "Secret in version "v1" cannot be handled as a Secret: json: cannot unmarshal string into Go struct field Secret.data of type map[string][]uint8"
 
 ## 0.6.4
 
-- Added support for specifying an optional service account name in the chart's values
-  - Added optional serviceAccount configuration section (commented out by default)
-  - Created serviceaccount.yaml template for conditional service account creation
-  - Updated deployment to conditionally use the specified service account
-  - **Non-breaking change**: Service account functionality is completely opt-in and disabled by default
+* Added support for specifying an optional service account name in the chart's values
+  * Added optional serviceAccount configuration section (commented out by default)
+  * Created serviceaccount.yaml template for conditional service account creation
+  * Updated deployment to conditionally use the specified service account
+  * **Non-breaking change**: Service account functionality is completely opt-in and disabled by default
 
 ## 0.6.5
 
-- Added support for client-managed secrets via `envFrom` configuration
-  - Allow loading environment variables from ConfigMaps and Secrets using the `envFrom` field
-  - **Non-breaking change**: `envFrom` functionality is completely opt-in and disabled by default
+* Added support for client-managed secrets via `envFrom` configuration
+  * Allow loading environment variables from ConfigMaps and Secrets using the `envFrom` field
+  * **Non-breaking change**: `envFrom` functionality is completely opt-in and disabled by default
 
 ## 0.6.6
 
-- Added support for pod-level and container-level [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) configuration
-  - Allow users to configure security contexts for enhanced security and compliance
-  - Added `podSecurityContext` and `containerSecurityContext` options in values.yaml for all charts (sombra, llm-classifier, pathfinder)
-  - **Non-breaking change**: Security context functionality is completely opt-in and disabled by default
+* Added support for pod-level and container-level [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) configuration
+  * Allow users to configure security contexts for enhanced security and compliance
+  * Added `podSecurityContext` and `containerSecurityContext` options in values.yaml for all charts (sombra, llm-classifier, pathfinder)
+  * **Non-breaking change**: Security context functionality is completely opt-in and disabled by default
 
 ## 0.6.7
 
-- See 0.6.6. This is a re-release of 0.6.6 to test an updated chart release process.
+* See 0.6.6. This is a re-release of 0.6.6 to test an updated chart release process.
 
 ## 0.6.8
 
-- Added support for host-aliases, and volume mounts to the Sombra customer-ingress pods.
+* Added support for host-aliases, and volume mounts to the Sombra customer-ingress pods.
 
 ## 0.7.0
 
-- Added support for specifying a custom termination grace period for Sombra pods.
+* Added support for specifying a custom termination grace period for Sombra pods.
 
 ## 0.8.0
 
-- Increase default memory and cpu allocation to prevent pod termination.
-- Relax `liveness` and `readiness` probe to prevent pod termination.
+* Increase default memory and cpu allocation to prevent pod termination.
+* Relax `liveness` and `readiness` probe to prevent pod termination. 
 
 ## 0.9.0
 
-- Added support for Asynchronous Sombra Job Scheduler.
+* Added support for Asynchronous Sombra Job Scheduler.
 
 ## 0.10.0
 
-- Added support for Kubernetes Downward API `fieldRef` environment variables via `envs_field_ref`.
-  - Supported in both the main Sombra chart and the sombra-job-scheduler subchart.
+* Added support for Kubernetes Downward API `fieldRef` environment variables via `envs_field_ref`.
+  * Supported in both the main Sombra chart and the sombra-job-scheduler subchart.
 
 ## 0.11.0
 
-- Added support for a Kubernetes `startupProbe` on the Sombra container.
-  - Defaults to the same `/health` endpoint on port `5042` used by the existing liveness and readiness probes, with a longer `failureThreshold` to accommodate slow start-ups.
-  - Configurable via the `startupProbe` field in `values.yaml`. Set `startupProbe: null` to disable it entirely.
-  - **Non-breaking change**: existing deployments will pick up the default startup probe; behaviour can be reverted by overriding or disabling the value.
+* Added support for a Kubernetes `startupProbe` on the Sombra container.
+  * Defaults to the same `/health` endpoint on port `5042` used by the existing liveness and readiness probes, with a longer `failureThreshold` to accommodate slow start-ups.
+  * Configurable via the `startupProbe` field in `values.yaml`. Set `startupProbe: null` to disable it entirely.
+  * **Non-breaking change**: existing deployments will pick up the default startup probe; behaviour can be reverted by overriding or disabling the value.
 
 ## 0.12.0
 
-- Added opt-in OPA (Open Policy Agent) sidecar support to the Sombra Deployment.
-  - Gated by `opa.enabled` (default `false`); existing single-container deployments are unchanged.
-  - Configurable `opa.image`, `opa.args`, `opa.env`/`opa.envFrom`, `opa.resources`, `opa.securityContext`, `opa.livenessProbe`/`opa.readinessProbe`/`opa.startupProbe`, `opa.lifecycle`, `opa.port`, and supplemental `opa.volumeMounts`.
-  - When `opa.config` is non-empty, a `<fullname>-opa-config` ConfigMap is rendered and mounted read-only at `opa.configMountPath` (as `opa.configFileName`), and `--config-file` is appended to generated or custom `opa.args`. A `checksum/opa-config` pod annotation rolls pods on config changes. When `opa.config` is empty and `opa.args` is null, no `args` key is rendered so the image `CMD` is preserved (e.g. seneca-opa baked config).
-  - OPA listens on `:8181` (all interfaces) by default so kubelet probes can reach `/health` via the pod IP, and is never exposed through the Sombra Service. Override `opa.args` and disable probes for strict loopback-only isolation.
-  - **Non-breaking change**: OPA is completely opt-in and disabled by default.
+* Added opt-in OPA (Open Policy Agent) sidecar support to the Sombra Deployment.
+  * Gated by `opa.enabled` (default `false`); existing single-container deployments are unchanged.
+  * Configurable `opa.image`, `opa.args`, `opa.env`/`opa.envFrom`, `opa.resources`, `opa.securityContext`, `opa.livenessProbe`/`opa.readinessProbe`/`opa.startupProbe`, `opa.lifecycle`, `opa.port`, and supplemental `opa.volumeMounts`.
+  * When `opa.config` is non-empty, a `<fullname>-opa-config` ConfigMap is rendered and mounted read-only at `opa.configMountPath` (as `opa.configFileName`), and `--config-file` is appended to generated or custom `opa.args`. A `checksum/opa-config` pod annotation rolls pods on config changes. When `opa.config` is empty and `opa.args` is null, no `args` key is rendered so the image `CMD` is preserved (e.g. seneca-opa baked config).
+  * OPA listens on `:8181` (all interfaces) by default so kubelet probes can reach `/health` via the pod IP, and is never exposed through the Sombra Service. Override `opa.args` and disable probes for strict loopback-only isolation.
+  * **Non-breaking change**: OPA is completely opt-in and disabled by default.
 
 ## 0.13.0
 
-- Made OPA `livenessProbe` and `readinessProbe` omitable via `null`, matching the existing `startupProbe` pattern. Setting `opa.readinessProbe: null` no longer renders invalid `readinessProbe: null` YAML.
-  - **ECS vs EKS failure-mode parity**: On ECS MTS, OPA runs with `essential=false`, so an OPA crash leaves Sombra in service and Seneca fails closed in-app. On EKS, any container readiness probe gates pod Ready; omit OPA readiness (`opa.readinessProbe: null`) so OPA outages do not drain Sombra from Service/ALB endpoints. Keep OPA liveness (default) to restart a wedged sidecar.
-  - **Non-breaking change**: default OPA probes are unchanged; existing installs keep current behavior unless consumers explicitly set probes to `null`.
+* Made OPA `livenessProbe` and `readinessProbe` omitable via `null`, matching the existing `startupProbe` pattern. Setting `opa.readinessProbe: null` no longer renders invalid `readinessProbe: null` YAML.
+  * **ECS vs EKS failure-mode parity**: On ECS MTS, OPA runs with `essential=false`, so an OPA crash leaves Sombra in service and Seneca fails closed in-app. On EKS, any container readiness probe gates pod Ready; omit OPA readiness (`opa.readinessProbe: null`) so OPA outages do not drain Sombra from Service/ALB endpoints. Keep OPA liveness (default) to restart a wedged sidecar.
+  * **Non-breaking change**: default OPA probes are unchanged; existing installs keep current behavior unless consumers explicitly set probes to `null`.
 
 ## 0.14.0
 
-- Raised default `opa.resources` so the OPA sidecar matches the ECS `opa-mts` Fargate reservation and can burst.
-  - Requests `50m/64Mi` → `250m/512Mi` (matches ECS `opa-mts` `cpu=256`/`memory=512`); limits `100m/128Mi` → `500m/1Gi` (2x headroom). The previous defaults made `requests` exceed `limits` once consumers bumped requests to `250m/512Mi`, which Kubernetes rejects.
-  - **Behavior change for opt-in OPA consumers**: deployments with `opa.enabled: true` and no `opa.resources` override now reserve more CPU/memory. Self-hosted consumers that pinned the old defaults should set `opa.resources` explicitly.
+* Raised default `opa.resources` so the OPA sidecar matches the ECS `opa-mts` Fargate reservation and can burst.
+  * Requests `50m/64Mi` → `250m/512Mi` (matches ECS `opa-mts` `cpu=256`/`memory=512`); limits `100m/128Mi` → `500m/1Gi` (2x headroom). The previous defaults made `requests` exceed `limits` once consumers bumped requests to `250m/512Mi`, which Kubernetes rejects.
+  * **Behavior change for opt-in OPA consumers**: deployments with `opa.enabled: true` and no `opa.resources` override now reserve more CPU/memory. Self-hosted consumers that pinned the old defaults should set `opa.resources` explicitly.

--- a/charts/sombra/Chart.yaml
+++ b/charts/sombra/Chart.yaml
@@ -9,10 +9,10 @@ maintainers:
 dependencies:
   - name: llm-classifier
     condition: llm-classifier.enabled
-    version: '0.2.2'
+    version: "0.2.2"
   - name: pathfinder
     condition: pathfinder.enabled
-    version: '0.2.2'
+    version: "0.2.2"
   - name: sombra-job-scheduler
     condition: sombra-job-scheduler.enabled
-    version: '0.1.4'
+    version: "0.1.4"

--- a/charts/sombra/Chart.yaml
+++ b/charts/sombra/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: sombra
 description: A Helm chart to deploy Sombra and its dependent services in a Kubernetes cluster
 type: application
-version: 0.13.0
+version: 0.14.0
 maintainers:
   - name: Transcend
     email: dev@transcend.io
 dependencies:
   - name: llm-classifier
     condition: llm-classifier.enabled
-    version: "0.2.2"
+    version: '0.2.2'
   - name: pathfinder
     condition: pathfinder.enabled
-    version: "0.2.2"
+    version: '0.2.2'
   - name: sombra-job-scheduler
     condition: sombra-job-scheduler.enabled
-    version: "0.1.4"
+    version: '0.1.4'

--- a/charts/sombra/tests/deployment_test.yaml
+++ b/charts/sombra/tests/deployment_test.yaml
@@ -94,37 +94,37 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: DD_SERVICE_NAME
-            value: 'testing-sombra-service'
+            value: "testing-sombra-service"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: ORGANIZATION_URI
-            value: 'some-org'
+            value: "some-org"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: IS_MULTI
-            value: 'false'
+            value: "false"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SOMBRA_ID
-            value: 'some-id'
+            value: "some-id"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: DATA_SUBJECT_AUTHENTICATION_METHODS
-            value: 'transcend,session'
+            value: "transcend,session"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: EMPLOYEE_AUTHENTICATION_METHODS
-            value: 'transcend,session'
+            value: "transcend,session"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: LLM_CLASSIFIER_URL
-            value: 'http://testing-llm-classifier.test-ns.svc:6081'
+            value: "http://testing-llm-classifier.test-ns.svc:6081"
 
   - it: should render fieldRef env vars from envs_field_ref
     set:
@@ -220,7 +220,7 @@ tests:
       namespace: test-ns
       envs:
         - name: ORGANIZATION_URI
-          value: 'test-org'
+          value: "test-org"
       envs_field_ref:
         - name: POD_NAME
           fieldPath: metadata.name
@@ -231,7 +231,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ORGANIZATION_URI
-            value: 'test-org'
+            value: "test-org"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/sombra/tests/deployment_test.yaml
+++ b/charts/sombra/tests/deployment_test.yaml
@@ -94,37 +94,37 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: DD_SERVICE_NAME
-            value: "testing-sombra-service"
+            value: 'testing-sombra-service'
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: ORGANIZATION_URI
-            value: "some-org"
+            value: 'some-org'
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: IS_MULTI
-            value: "false"
+            value: 'false'
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SOMBRA_ID
-            value: "some-id"
+            value: 'some-id'
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: DATA_SUBJECT_AUTHENTICATION_METHODS
-            value: "transcend,session"
+            value: 'transcend,session'
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: EMPLOYEE_AUTHENTICATION_METHODS
-            value: "transcend,session"
+            value: 'transcend,session'
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: LLM_CLASSIFIER_URL
-            value: "http://testing-llm-classifier.test-ns.svc:6081"
+            value: 'http://testing-llm-classifier.test-ns.svc:6081'
 
   - it: should render fieldRef env vars from envs_field_ref
     set:
@@ -220,7 +220,7 @@ tests:
       namespace: test-ns
       envs:
         - name: ORGANIZATION_URI
-          value: "test-org"
+          value: 'test-org'
       envs_field_ref:
         - name: POD_NAME
           fieldPath: metadata.name
@@ -231,7 +231,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ORGANIZATION_URI
-            value: "test-org"
+            value: 'test-org'
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -318,11 +318,11 @@ tests:
           path: spec.template.spec.containers[1].resources
           value:
             limits:
-              cpu: 100m
-              memory: 128Mi
+              cpu: 500m
+              memory: 1Gi
             requests:
-              cpu: 50m
-              memory: 64Mi
+              cpu: 250m
+              memory: 512Mi
       - notExists:
           path: spec.template.spec.containers[1].lifecycle
       - contains:

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -31,12 +31,12 @@ image:
   # Define the pullPolicy for Sombra image
   pullPolicy: IfNotPresent
   # Sombra version to deploy
-  tag: 'latest'
+  tag: "latest"
 
 # Override name of app
-nameOverride: ''
+nameOverride: ""
 # Override the full qualified app name
-fullnameOverride: ''
+fullnameOverride: ""
 
 # Service account configuration (optional)
 # Uncomment and configure this section if you want to use a custom service account
@@ -135,17 +135,17 @@ transcend_ingress:
 # These environment variables are saved as secret
 envs_as_secret:
   - name: JWT_ECDSA_KEY
-    value: '<JWT_ECDSA_KEY>'
+    value: "<JWT_ECDSA_KEY>"
 
 envs:
   - name: ORGANIZATION_URI
-    value: 'some-org'
+    value: "some-org"
   - name: SOMBRA_ID
-    value: 'some-id'
+    value: "some-id"
   - name: EMPLOYEE_AUTHENTICATION_METHODS
-    value: 'transcend,session'
+    value: "transcend,session"
   - name: DATA_SUBJECT_AUTHENTICATION_METHODS
-    value: 'transcend,session'
+    value: "transcend,session"
 
 # Environment variables populated via the Downward API (fieldRef).
 # Exposes pod and node metadata as environment variables.
@@ -167,16 +167,16 @@ isMultiTenant: false
 
 # Configuration for log forwarding to Transcend
 datadog:
-  serviceName: 'customer_hosted_sombra'
+  serviceName: "customer_hosted_sombra"
 
 # Resource requests and limits for the Sombra pod
 resources:
   requests:
-    cpu: '2'
-    memory: '8Gi'
+    cpu: "2"
+    memory: "8Gi"
   limits:
-    cpu: '3'
-    memory: '12Gi'
+    cpu: "3"
+    memory: "12Gi"
 
 # Health check configuration
 livenessProbe:
@@ -276,7 +276,7 @@ opa:
     # Transcend EKS deploys should override repository/tag to the internal
     # seneca-opa image; this default is for generic chart use.
     repository: openpolicyagent/opa
-    tag: '0.70.0-static'
+    tag: "0.70.0-static"
     pullPolicy: IfNotPresent
 
   # Replaces image CMD when non-null. Omit (null) to use the image entrypoint —
@@ -303,11 +303,11 @@ opa:
   # sidecar 2x headroom to burst. Tune from load-test data.
   resources:
     requests:
-      cpu: '250m'
-      memory: '512Mi'
+      cpu: "250m"
+      memory: "512Mi"
     limits:
-      cpu: '500m'
-      memory: '1Gi'
+      cpu: "500m"
+      memory: "1Gi"
 
   # Container-level security context.
   securityContext: {}

--- a/charts/sombra/values.yaml
+++ b/charts/sombra/values.yaml
@@ -31,12 +31,12 @@ image:
   # Define the pullPolicy for Sombra image
   pullPolicy: IfNotPresent
   # Sombra version to deploy
-  tag: "latest"
+  tag: 'latest'
 
 # Override name of app
-nameOverride: ""
+nameOverride: ''
 # Override the full qualified app name
-fullnameOverride: ""
+fullnameOverride: ''
 
 # Service account configuration (optional)
 # Uncomment and configure this section if you want to use a custom service account
@@ -135,17 +135,17 @@ transcend_ingress:
 # These environment variables are saved as secret
 envs_as_secret:
   - name: JWT_ECDSA_KEY
-    value: "<JWT_ECDSA_KEY>"
+    value: '<JWT_ECDSA_KEY>'
 
 envs:
   - name: ORGANIZATION_URI
-    value: "some-org"
+    value: 'some-org'
   - name: SOMBRA_ID
-    value: "some-id"
+    value: 'some-id'
   - name: EMPLOYEE_AUTHENTICATION_METHODS
-    value: "transcend,session"
+    value: 'transcend,session'
   - name: DATA_SUBJECT_AUTHENTICATION_METHODS
-    value: "transcend,session"
+    value: 'transcend,session'
 
 # Environment variables populated via the Downward API (fieldRef).
 # Exposes pod and node metadata as environment variables.
@@ -167,16 +167,16 @@ isMultiTenant: false
 
 # Configuration for log forwarding to Transcend
 datadog:
-  serviceName: "customer_hosted_sombra"
+  serviceName: 'customer_hosted_sombra'
 
 # Resource requests and limits for the Sombra pod
 resources:
   requests:
-    cpu: "2"
-    memory: "8Gi"
+    cpu: '2'
+    memory: '8Gi'
   limits:
-    cpu: "3"
-    memory: "12Gi"
+    cpu: '3'
+    memory: '12Gi'
 
 # Health check configuration
 livenessProbe:
@@ -276,7 +276,7 @@ opa:
     # Transcend EKS deploys should override repository/tag to the internal
     # seneca-opa image; this default is for generic chart use.
     repository: openpolicyagent/opa
-    tag: "0.70.0-static"
+    tag: '0.70.0-static'
     pullPolicy: IfNotPresent
 
   # Replaces image CMD when non-null. Omit (null) to use the image entrypoint —
@@ -298,15 +298,16 @@ opa:
   # keep `--addr` in sync when changing this value.
   port: 8181
 
-  # Resource requests and limits for the OPA container. Defaults are
-  # intentionally conservative; tune from load-test data.
+  # Resource requests and limits for the OPA container. Requests match the
+  # ECS opa-mts Fargate reservation (cpu=256 / memory=512); limits give the
+  # sidecar 2x headroom to burst. Tune from load-test data.
   resources:
     requests:
-      cpu: "50m"
-      memory: "64Mi"
+      cpu: '250m'
+      memory: '512Mi'
     limits:
-      cpu: "100m"
-      memory: "128Mi"
+      cpu: '500m'
+      memory: '1Gi'
 
   # Container-level security context.
   securityContext: {}


### PR DESCRIPTION
## Related Issues

- ref https://linear.app/transcend/issue/LINK-6867/opa-sidecar-containment-decision-log-wrapper-in-sombra-pod-template

## Internal Changelog

- Updated: Default `opa.resources` for the opt-in OPA sidecar so requests/limits match the ECS `opa-mts` reservation and no longer reject when consumers bump only requests.
- Updated: Sombra chart version `0.13.0` → `0.14.0`.

<details>
<summary>Implementation details</summary>

### Problem

[transcend-io/main#46530](https://github.com/transcend-io/main/pull/46530) raised EKS OPA `requests` to `250m/512Mi` to match ECS `opa-mts`, but left the chart default `limits` at `100m/128Mi`. Kubernetes rejected the Deployment (`requests must be less than or equal to limit`), and staging deploy failed ([run](https://github.com/transcend-io/main/actions/runs/30910563846/job/91999589333#step:5:3085)). [transcend-io/main#46704](https://github.com/transcend-io/main/pull/46704) reverted the bump to unblock staging.

### Fix

Raise chart default `opa.resources` (requests and limits) so opt-in OPA consumers do not need a per-deployment `limits` override or `limits: null` workaround.

| | Before | After |
| --- | --- | --- |
| Requests | `50m` / `64Mi` | `250m` / `512Mi` (ECS `opa-mts` `cpu=256` / `memory=512`) |
| Limits | `100m` / `128Mi` | `500m` / `1Gi` (2x burst headroom) |

### Scope / behavior

- Affects only the OPA sidecar when `opa.enabled: true` (container block gated by `{{- if $opa.enabled }}`).
- Main Sombra container uses top-level `resources` and is unchanged.
- Pods with OPA disabled are unaffected.
- Opt-in OPA consumers with no `opa.resources` override now reserve more CPU/memory; self-hosted installs that need the old defaults should set `opa.resources` explicitly.

### Files

- `charts/sombra/values.yaml` — default resources
- `charts/sombra/Chart.yaml` — version bump
- `charts/sombra/tests/deployment_test.yaml` — assertion update
- `charts/sombra/CHANGELOG.md` — `0.14.0` entry

### Follow-up (main repo)

After chart-releaser publishes `0.14.0`, bump the pinned chart `0.13.0` → `0.14.0` and drop any Pulumi `opa.resources` override that was compensating for the old defaults.

### Related

- Original bump: [transcend-io/main#46530](https://github.com/transcend-io/main/pull/46530)
- Revert: [transcend-io/main#46704](https://github.com/transcend-io/main/pull/46704)

</details>

## Test plan

- [x] `helm lint charts/sombra`
- [x] `helm unittest sombra` — 21/21 pass
- [x] CI Helm chart tests job green (`test`, `check-chart-lock`)
- [ ] After merge: chart-releaser publishes `0.14.0`; follow-up `main` PR bumps chart pin and drops Pulumi `opa.resources` override